### PR TITLE
Fix Codecov upload

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -24,3 +24,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^CITATION\.cff$
+^codecov\.yml$

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
 [![R build status](https://github.com/j-idea/daedalus/workflows/R-CMD-check/badge.svg)](https://github.com/j-idea/daedalus/actions/workflows/R-CMD-check.yaml)
-[![codecov.io](https://codecov.io/github/j-idea/daedalus/coverage.svg?branch=main)](https://codecov.io/github/j-idea/daedalus?branch=main)
+[![Codecov test coverage](https://codecov.io/gh/j-idea/daedalus/branch/main/graph/badge.svg)](https://app.codecov.io/gh/j-idea/daedalus?branch=main)
 [![CRAN status](https://www.r-pkg.org/badges/version/daedalus)](https://CRAN.R-project.org/package=daedalus)
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ or
 proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
 [![R build
 status](https://github.com/j-idea/daedalus/workflows/R-CMD-check/badge.svg)](https://github.com/j-idea/daedalus/actions/workflows/R-CMD-check.yaml)
-[![codecov.io](https://codecov.io/github/j-idea/daedalus/coverage.svg?branch=main)](https://codecov.io/github/j-idea/daedalus?branch=main)
+[![Codecov test
+coverage](https://codecov.io/gh/j-idea/daedalus/branch/main/graph/badge.svg)](https://app.codecov.io/gh/j-idea/daedalus?branch=main)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/daedalus)](https://CRAN.R-project.org/package=daedalus)
 <!-- badges: end -->

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true


### PR DESCRIPTION
This PR adds a missing `codecov.yml` config file.

Previously [failing code coverage workflow](https://github.com/j-idea/daedalus/actions/runs/9859281474/job/27222634689) fixed by setting up Codecov integration.